### PR TITLE
Remove seeding step from start script for immediate testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "server-dev": "nodemon server.js",
     "server-prod": "node server.js",
     "seed": "node server/seed.js",
-    "start": "npm run seed && npm run client-build && npm run server-prod"
+    "start": "npm run client-build && npm run server-prod"
   },
   "dependencies": {
     "@babel/preset-env": "^7.15.0",


### PR DESCRIPTION
This change updates the start script in package.json to remove the seeding step. By doing this, we can avoid reseeding the database each time the application starts.